### PR TITLE
Add reference to the time to completion in copywriting

### DIFF
--- a/components/PostAuth/CardStates.jsx
+++ b/components/PostAuth/CardStates.jsx
@@ -8,7 +8,7 @@ export const Confirming = ({ cid, err }) => {
     <>
       <Text>
         We're making sure your FIL request gets processed by the Filecoin
-        network...
+        network. This might take 2-3 minutes.
       </Text>
       <Box
         display='flex'

--- a/components/PostAuth/CardStates.jsx
+++ b/components/PostAuth/CardStates.jsx
@@ -8,7 +8,7 @@ export const Confirming = ({ cid, err }) => {
     <>
       <Text>
         We're making sure your FIL request gets processed by the Filecoin
-        network. This might take 2-3 minutes.
+        network. This might take up to 5 minutes.
       </Text>
       <Box
         display='flex'


### PR DESCRIPTION
# Changes
- Once an address is inputted and the user starts the faucet, the copywriting now mentions that the transaction may take 2-3 minutes to complete.

# Closes
#1 